### PR TITLE
Include CSS when required and allow disabling

### DIFF
--- a/oembed-gist.php
+++ b/oembed-gist.php
@@ -76,6 +76,8 @@ class gist {
 
 	public function gist_css()
 	{
+        $inject_css = true;
+        if ( apply_filters( 'oembed_gist_inject_css', $inject_css ) ) {
 		?>
 		<style>
 		.gist table {
@@ -105,6 +107,7 @@ class gist {
 		}
 		</style>
 		<?php
+        }
 	}
 
 	public function handler( $m, $attr, $url, $rattr )

--- a/oembed-gist.php
+++ b/oembed-gist.php
@@ -24,8 +24,6 @@ class gist {
 
 	public function plugins_loaded()
 	{
-		add_action( 'wp_head', array( $this, 'wp_head' ) );
-
 		load_plugin_textdomain(
 			'oembed-gist',
 			false,
@@ -76,7 +74,7 @@ class gist {
 		return $providers;
 	}
 
-	public function wp_head()
+	public function gist_css()
 	{
 		?>
 		<style>
@@ -145,6 +143,7 @@ class gist {
 		if( is_feed() ){
 			return $noscript;
 		}else{
+            add_action( 'wp_footer', array( $this, 'gist_css' ) );
 			return sprintf(
 				'<div class="oembed-gist"><script src="%s"></script><noscript>%s</noscript></div>',
 				$url,


### PR DESCRIPTION
Fixes for
#17: Rename wp_head() to gist_css() and only call the function when the shortcode is used.
and
#18: Use apply_filters() to allow disabling the injected CSS.
It can be disabled with:
add_filter( 'oembed_gist_inject_css', '__return_false');


