### PR TITLE
Output link when outputting AMP with wp-amp

### DIFF
--- a/oembed-gist.php
+++ b/oembed-gist.php
@@ -130,6 +130,11 @@ class gist {
 			$url = 'https://gist.github.com/' . $p['id'];
 		}
 
+		// If displaying AMP page with wp-amp plugin - return link.
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return sprintf( __( '<a href="%s">See the gist on github</a>.', 'oembed-gist' ), esc_url( $url ) );
+		}
+
 		$noscript = sprintf(
 			__( 'View the code on <a href="%s">Gist</a>.', 'oembed-gist' ),
 			esc_url( $url )


### PR DESCRIPTION
Output from the plugin is stripped when viewing a post as AMP, so attempt to detect it and return a link instead of the embed code.
This pull detects the popular AMP plugin from Automattic: https://github.com/Automattic/amp-wp/

Without this an AMP using this plugin can end up useless as it just has holes in the content.